### PR TITLE
Allow aggregating expression by multiple columns

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -58,10 +58,11 @@ get_distances <- function(ccs, method = "euclidean", matrix = T) {
 #' @noRd
 #'
 aggregated_expr_data <- function(cds, 
-                                 group_cells_by = "cell_type", 
+                                 group_cells_by = "cell_type",
                                  gene_group_df = NULL,
-                                 gene_agg_fun = "sum", 
-                                 cell_agg_fun = "mean") {
+                                 gene_agg_fun = "sum",
+                                 cell_agg_fun = "mean",
+                                 calculate_specificity = TRUE) {
   
   coldata_df <- as.data.frame(colData(cds)) %>%
     filter(if_all(group_cells_by, ~ !is.na(.x) & .x != ""))
@@ -120,14 +121,17 @@ aggregated_expr_data <- function(cds,
 
   cluster_fraction_expressing_table$mean_expression <- cluster_expr_table$mean_expression
 
-  cluster_spec_mat <- monocle3:::specificity_matrix(cluster_mean_exprs)
-  cluster_spec_table <- tibble::rownames_to_column(as.data.frame(cluster_spec_mat))
-  cluster_spec_table <- tidyr::gather(
-    cluster_spec_table, "cell_group",
-    "specificity", -rowname
-  )
+  if (calculate_specificity) {
+    cluster_spec_mat <- monocle3:::specificity_matrix(cluster_mean_exprs)
+    cluster_spec_table <- tibble::rownames_to_column(as.data.frame(cluster_spec_mat))
+    cluster_spec_table <- tidyr::gather(
+      cluster_spec_table, "cell_group",
+      "specificity", -rowname
+    )
 
-  cluster_fraction_expressing_table$specificity <- cluster_spec_table$specificity
+    cluster_fraction_expressing_table$specificity <- cluster_spec_table$specificity
+  }
+  
   cluster_fraction_expressing_table <- cluster_fraction_expressing_table %>%
     dplyr::rename("gene_id" = rowname) %>%
     dplyr::left_join(


### PR DESCRIPTION
I extended `hooke:::aggregated_expr_data()` so that the user can specify multiple columns to aggregate by (e.g. both cell type and perturbation). I tested the updated function on default parameters and confirmed that it still returns the same result -- `mean_expression`, `fraction_expressing`, and `specificity` is equal for all values and the first column of the result is still `cell_group` if there is only one column. However, if multiple columns are specified, the result now puts all of those columns first, for example:
```r
agg_expr <- hooke:::aggregated_expr_data(cds, c("perturbation", "cell_type_broad_abbrev")) %>%
  head()
```
returns:
```
  perturbation cell_type_broad_abbrev            gene_id gene_short_name
1     ctrl-inj                    RPC ENSDARG00000000001         slc35a5
2     ctrl-inj                    RPC ENSDARG00000000002          ccdc80
3     ctrl-inj                    RPC ENSDARG00000000018            nrf1
4     ctrl-inj                    RPC ENSDARG00000000019           ube2h
5     ctrl-inj                    RPC ENSDARG00000000068       slc9a3r1a
6     ctrl-inj                    RPC ENSDARG00000000069             dap
  fraction_expressing mean_expression specificity
1         0.002456332     0.002757203 0.051766341
2         0.002183406     0.001340389 0.075315424
3         0.086244541     0.083973716 0.077649102
4         0.021834061     0.019834487 0.016199531
5         0.003548035     0.002764963 0.008075803
6         0.036026201     0.034195728 0.027027247
```