### PR TITLE
Add CLAUDE.md; reduce AGENTS.md to a pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,4 @@
-# Codex instructions (Hooke)
+# See CLAUDE.md
 
-## What this repo is
-Hooke is an R package used in the Trapnell Lab stack for statistical analysis of single-cell perturbation data.
-
-# Codex instructions (Hooke)
-
-Hooke is an R package used in the Trapnell Lab stack for statistical analysis of single-cell perturbation data.
-
-## Cost & safety guardrails
-- Safe to run R package checks and unit tests (minutes).
-- Do NOT run long benchmarks or full-dataset analyses unless explicitly requested.
-- Never commit secrets, credentials, or private datasets.
-
-## Change expectations
-- Prefer small PRs (<300 LOC changed when possible).
-- If changing exported functions, update:
-  - roxygen docs (if used)
-  - tests
-  - NEWS.md (if present)
-- If changing object structures or outputs, add a backward-compat test or a migration note.
-- When adding dependencies, keep them minimal and declare them in `DESCRIPTION`; avoid heavy, non-CRAN dependencies unless justified.
-
-## Validation tiers
-- **FAST (default; safe):** `make fast` (runs `testthat::test_local` with summary reporter; should finish in minutes and not build the package).
-- **SMOKE (opt-in):** Small toy example / vignette using tiny fixtures only.
-- **FULL (manual only):** Real dataset runs / benchmarks.
+Agent instructions for this repo live in `CLAUDE.md`.
+This file is kept only so tools that look for AGENTS.md find the pointer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# hooke
+
+R package: differential analysis of **cell counts / abundances** in single-cell experiments.
+Upstream of `platt`; consumed by sulston, mcclintock, lewis, zscape_portal.
+
+## Commands (verified in Makefile)
+```bash
+make fast     # == make test
+make test     # Rscript -e 'testthat::test_local(".", reporter="summary", stop_on_failure=TRUE)'
+make check    # R CMD check --no-manual .
+```
+3 test files: `test-cell_count_model.R`, `test-cell_count_set.R`, `test-contrasts.R`.
+
+## Gotchas
+- `HOOKE_SKIP_DEP_CHECK=1` **skips the entire test suite**, not just a dependency probe.
+  A green `make fast` under that flag means nothing ran. (The root README describes it
+  as bypassing a "dependency check" — that wording is wrong.)
+- `Depends: PLNmodels`, which is not on CRAN in a usable version — CI installs
+  `PLN-team/PLNmodels@master`. Locally: `Rscript scripts/install_hooke_deps.R` from the stack root.
+- `Remotes: bioc::Rgraphviz`. `LinkingTo: Rcpp` + `src/` — changing `src/` needs a recompile.
+- `power` is post-hoc and `mdfc` is contaminated — prefer `delta_log_abund_se` and MDFC80.
+
+## Release notes
+`NEWS.md` exists (seeded at 0.0.1, no prior history). Bump `Version:` in `DESCRIPTION` and add the
+matching `# hooke <version>` / `### Changes` section in the same commit. See the root `CLAUDE.md`
+convention and `repos/monocle3/NEWS.md` for the reference format.
+
+## Architecture
+`R/` is the whole surface; exported API in `NAMESPACE`, roxygen markdown enabled (7.3.2).
+
+## CI
+`.github/workflows/check_on_push.yml`, `on: [push]`: `R CMD build` + `R CMD check` inside
+`ghcr.io/cole-trapnell-lab/monocle3_depend:v1.3.0_1`, with `TRAVIS=true` and
+`_R_CHECK_TESTS_NLINES_=0`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,18 @@
+# hooke 0.0.1
+
+Release notes start here. Hooke has not yet had a version bump, so there is no
+prior history to document.
+
+When you bump `Version:` in `DESCRIPTION`, add a section above this one:
+
+```
+# hooke <new version>
+
+### Changes
+
+* One bullet per user-visible change.
+```
+
+Document what a caller would notice — new or removed exported functions, changed
+defaults, changed return shapes, bug fixes that alter results. Internal
+refactors that leave the API and the numbers alone do not need an entry.


### PR DESCRIPTION
Replaces the Codex-era AGENTS.md with a CLAUDE.md built from verified repo state. Every build and test command in the new file was confirmed against the Makefile, DESCRIPTION/pyproject and CI config rather than carried over from the old file.

Adds NEWS.md, seeded at 0.0.1 per the new stack convention for version bumps.

AGENTS.md is kept as a four-line pointer so tools that look for it still resolve to the current instructions.