### PR TITLE
Replace power/mdfc with effect-independent detectability columns (0.0.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,13 @@ make check    # R CMD check --no-manual .
 - `Depends: PLNmodels`, which is not on CRAN in a usable version — CI installs
   `PLN-team/PLNmodels@master`. Locally: `Rscript scripts/install_hooke_deps.R` from the stack root.
 - `Remotes: bioc::Rgraphviz`. `LinkingTo: Rcpp` + `src/` — changing `src/` needs a recompile.
-- `power` is post-hoc and `mdfc` is contaminated — prefer `delta_log_abund_se` and MDFC80.
+- 0.0.3 **removed the `mdfc` column**; `calculate_mdfc()` was fixed in place and now emits
+  `mdfc80`. The two are not interchangeable — the value differs on essentially every row,
+  so thresholds picked against `mdfc` need rechoosing. `calculate_power()` is now
+  `calculate_observed_power()`, published as `observed_power`, with `power` a deprecated
+  alias for one release. `observed_power` is `delta_p_value` restated (strictly increasing
+  in `|Z|`), so filtering on it before `p.adjust()` is anti-conservative. Filter on
+  `mdfc80` or `power_at_margin` — the only effect-independent columns.
 
 ## Release notes
 `NEWS.md` exists (seeded at 0.0.1, no prior history). Bump `Version:` in `DESCRIPTION` and add the

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hooke
 Title: Differential analysis of cell counts in single-cell experiments
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: 
     person(given = "Madeleine",
            family = "Duran",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,74 @@
+# hooke 0.0.3
+
+### Breaking changes
+
+* `compare_abundances()` no longer returns `mdfc`. `calculate_mdfc()` has been
+  fixed rather than frozen, and the corrected quantity is published as
+  `mdfc80`. The two are **not interchangeable**: the value differs on
+  essentially every row, and any threshold chosen against `mdfc` needs
+  rechoosing. Code reading `mdfc` now fails loudly rather than silently getting
+  a number that means something else.
+  * The old value was `exp((z_alpha + z_observed) * SE)`, because a
+    `dplyr::mutate()` bound `power = power` to the column created on the line
+    above instead of to the formal argument, feeding the observed power in
+    where a requested power level belonged. It was understated on most rows,
+    smallest exactly where the data are weakest, and `Inf` on the *most*
+    significant rows (`qnorm(1) = Inf`) rather than on degenerate ones.
+  * `calculate_mdfc()` now takes `df` and `base`, and its `Inf` guard tests the
+    standard errors alone. The old guard also tested `power == 0`, so it fired
+    only as a side effect of the contamination; with a constant power it would
+    have reported a 1-fold detection limit for a degenerate fit. Such rows are
+    now `NA`, with the reason in `contrast_note`.
+* `calculate_power()` is renamed `calculate_observed_power()`, and the column is
+  published as `observed_power`. `power` remains as a **deprecated alias** for
+  one release and is bit-identical to 0.0.2.
+
+### Changes
+
+* `compare_abundances()` gains the columns needed to tell "no phenotype" apart
+  from "not powered". Every retained column, `power` included, is bit-identical
+  to 0.0.2.
+  * `mdfc80` -- minimum detectable fold change at the requested `power`: the
+    smallest change the contrast could have caught.
+  * `power_at_margin` -- power to detect a change of `margin`. The dual of
+    `mdfc80`: it fixes the effect size and reports the power, where `mdfc80`
+    fixes the power and reports the effect size. Computed exactly, from the
+    noncentral t.
+  * `margin_fold_change` -- the `margin` used, so the table records what it was
+    powered for rather than leaving a reader to guess.
+  * `delta_log_abund_lo` / `delta_log_abund_hi` -- Wald confidence interval on
+    `delta_log_abund` at level `1 - alpha`.
+  * `df_resid` -- residual degrees of freedom. Previously computed and
+    discarded, so nothing downstream could rebuild an interval or an
+    equivalence test from the published table.
+  * `contrast_note` -- why `mdfc80` and `power_at_margin` are `NA`:
+    `"degenerate_fit"` or `"insufficient_df"`; `NA` when the row is fine.
+* New `margin` argument, the effect size to power against, given as a **fold
+  change** (default `2`) so it means the same thing regardless of `log_scale`
+  and `convert_scale`. It is converted to the result's log scale internally.
+* `mdfc80` and `power_at_margin` are **effect-independent**: functions of
+  `delta_log_abund_se`, `alpha`, `df_resid` and a declared constant only, never
+  of the observed effect. That is what makes either a fair answer to "were we
+  powered to see a phenotype here?", and what makes them safe to filter on.
+  Both use t quantiles, matching `delta_p_value`, rather than the normal
+  approximation; at 8 residual df the normal approximation understates the
+  detectable effect by roughly 15%. Both exponentiate in the base implied by
+  `log_scale`/`convert_scale`, where the old `calculate_mdfc()` hardcoded
+  `exp()`.
+* `observed_power` is retained but should not be used to decide whether a null
+  result is meaningful. It substitutes the observed Wald statistic for the true
+  effect, which makes it strictly increasing in `|Z|` and so a deterministic
+  restatement of `delta_p_value`: `>= 0.8` is exactly `p <= ~0.008`. It does not
+  measure precision -- a cell type with a huge standard error and a fluke
+  estimate scores high, while a tightly measured genuine null scores the floor.
+* `compare_abundances(adjust_q_values = TRUE)` now restricts the correction
+  using `power_at_margin` rather than `power`, and warns. Filtering on `power`
+  selected rows by their p-value and then adjusted those same p-values, which is
+  anti-conservative; `power_at_margin` is effect-independent, so the filter is
+  defensible. It still changes what the FDR guarantee covers -- the adequately
+  powered subset, not every row tested. The default is unchanged (`FALSE`), and
+  it is not enabled in production.
+
 # hooke 0.0.2
 
 ### Changes

--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -506,9 +506,25 @@ estimate_abundances_over_interval <- function(ccm,
 }
 
 
-# Calculates the power to detect a significant change in a given contrast
-# Power is the probability of avoiding a Type II error
-calculate_power <- function(beta_x, SE_x, beta_y, SE_y, alpha = 0.05) {
+# Post-hoc ("observed") power for a contrast.
+#
+# Renamed from calculate_power() in 0.0.3 to say what it computes. The body is
+# unchanged, so the deprecated `power` column keeps its published values.
+#
+# WARNING: this is not a power calculation in the design sense. It substitutes
+# the OBSERVED Wald statistic for the true effect, which makes it strictly
+# increasing in |Z| and therefore a deterministic restatement of
+# `delta_p_value` -- `power >= 0.8` is exactly `p <= ~0.008`. It floors at
+# `alpha` when Z = 0 and saturates at 1 for |Z| >= ~10.26.
+#
+# It does not measure precision: a cell type with a huge SE and a fluke
+# estimate scores high, while a tightly measured genuine null scores the floor.
+# Filtering on it before p.adjust() selects on the statistic being adjusted and
+# is anti-conservative.
+#
+# For "were we powered to see a change here?" use calculate_power_at_margin()
+# or calculate_mdfc(), both of which are effect-independent.
+calculate_observed_power <- function(beta_x, SE_x, beta_y, SE_y, alpha = 0.05) {
   # Wald test statistic for comparing two groups
   Z <- (beta_x - beta_y) / sqrt(SE_x^2 + SE_y^2)
 
@@ -524,22 +540,92 @@ calculate_power <- function(beta_x, SE_x, beta_y, SE_y, alpha = 0.05) {
   return(power)
 }
 
-# Estimates the smallest fold change you can detect at a given power level
-calculate_mdfc <- function(SE_x, SE_y, alpha = 0.05, power = 0.8) {
-  # Z-scores for significance and power
-  Z_alpha <- qnorm(1 - alpha / 2) # Two-tailed
-  Z_power <- qnorm(power)
+# Linear-scale base implied by a log scale name.
+log_base_value <- function(log_scale) {
+  switch(log_scale,
+    log = exp(1),
+    log2 = 2,
+    log10 = 10,
+    stop("Unrecognized log scale: ", log_scale)
+  )
+}
 
-  # Compute minimum detectable effect size (beta difference)
-  delta_beta <- (Z_alpha + Z_power) * sqrt(SE_x^2 + SE_y^2)
+# Minimum detectable fold change at a REQUESTED power level.
+#
+# Fixed in 0.0.3. Before that this function was called with the OBSERVED power
+# vector rather than a requested power level, because a dplyr::mutate() bound
+# `power = power` to the column created on the line above instead of to the
+# formal argument. The stored value was therefore
+# exp((z_alpha + z_observed) * SE): understated on most rows, smallest exactly
+# where the data are weakest, and Inf on the most significant rows
+# (qnorm(1) = Inf). It also hardcoded exp(), inflating log2 SEs, and its Inf
+# guard tested `power == 0` alongside the SEs, so it only ever fired as a side
+# effect of that same contamination.
+#
+# It now depends only on the standard errors, `alpha`, the residual degrees of
+# freedom and `power` -- never on the observed effect. That effect-independence
+# is what makes it eligible as a filter, or as the basis of a "we would have
+# caught a change this large" claim.
+#
+# Uses t quantiles so that the detection limit and `delta_p_value` refer to the
+# same distribution; with 6-13 samples per arm the normal approximation is
+# optimistic. This is the normal-theory MDE formula with t quantiles
+# substituted, not an exact noncentral-t solution -- close enough at these df,
+# and slightly conservative.
+#
+# `base` is the linear-scale base matching the log scale of the SEs, so that a
+# log2 contrast yields a log2-consistent fold change rather than an exp() one.
+#
+# Returns NA (never Inf, never 1) where no detection limit is defined: a zero
+# or non-finite SE is a degenerate fit, not a 1-fold detection limit. Callers
+# get the reason in `contrast_note`.
+calculate_mdfc <- function(SE_x, SE_y, alpha = 0.05, power = 0.8,
+                                    df = NULL, base = exp(1)) {
+  se <- sqrt(SE_x^2 + SE_y^2)
 
-  # Convert to fold change
-  MDFC <- exp(delta_beta)
+  if (is.null(df) || length(df) != 1 || !is.finite(df) || df <= 0) {
+    return(rep(NA_real_, length(se)))
+  }
 
-  # if power is 0, no fold change is detectable
-  MDFC <- ifelse(power == 0 & SE_x == 0 & SE_y == 0, Inf, MDFC)
+  MDFC <- base^((qt(1 - alpha / 2, df) + qt(power, df)) * se)
+  MDFC[!is.finite(se) | se <= 0] <- NA_real_
 
   return(MDFC)
+}
+
+# Power to detect a change of a DECLARED size.
+#
+# The dual of calculate_mdfc(): that one fixes the power and reports
+# the detectable effect, this one fixes the effect and reports the power. Both
+# depend only on the standard errors, `alpha`, `df` and a declared quantity --
+# never on the observed effect -- which is what makes either of them a fair
+# answer to "were we powered to see a phenotype here?".
+#
+# `margin_log` is the effect size to be powered against, on the same log scale
+# as the standard errors. Under the alternative that the true difference equals
+# that margin, the t statistic follows a noncentral t with ncp = margin / SE,
+# so two-sided power is the mass beyond +/- tcrit.
+#
+# Returns NA where SE or df make the question meaningless, matching
+# calculate_mdfc().
+calculate_power_at_margin <- function(SE_x, SE_y, alpha = 0.05, margin_log,
+                                      df = NULL) {
+  se <- sqrt(SE_x^2 + SE_y^2)
+
+  if (is.null(df) || length(df) != 1 || !is.finite(df) || df <= 0) {
+    return(rep(NA_real_, length(se)))
+  }
+
+  usable <- is.finite(se) & se > 0
+  power <- rep(NA_real_, length(se))
+
+  tcrit <- qt(1 - alpha / 2, df)
+  ncp <- abs(margin_log) / se[usable]
+
+  power[usable] <-
+    (1 - pt(tcrit, df, ncp = ncp)) + pt(-tcrit, df, ncp = ncp)
+
+  return(power)
 }
 
 
@@ -568,11 +654,73 @@ convert_base <- function(value, from_base, to_base) {
 #' @param method string A method for correcting P-value multiple comparisons.
 #'    This can be "BH" (Benjamini & Hochberg), "bonferroni" (Bonferroni),
 #'    "hochberg" (Hochberg), "hommel", (Hommel), or "BYH" (Benjamini & Yekutieli).
-#' @param alpha Desired significance level
-#' @param power Desired power level for calculating minimum detectable fold change
+#' @param alpha Desired significance level.
+#' @param power Desired power level, used for `mdfc80`.
+#' @param margin The effect size to be powered against, as a **fold change**
+#'   (so `2` means a two-fold change), used for `power_at_margin`. Given as a
+#'   fold change rather than on a log scale so that it means the same thing
+#'   regardless of `log_scale`/`convert_scale`.
 #' @param convert_scale Whether to convert to log2 scale.
+#' @param adjust_q_values Whether to restrict multiple-testing correction to the
+#'   rows with `power_at_margin >= power`. Changes what the FDR guarantee
+#'   covers; see [adjust_q_values()]. Defaults to `FALSE`.
 #' @param log_scale Log scale used for estimate_abundances.
-#' @return tibble A table contrasting cond_x and cond_y (interpret as Y/X).
+#' @return tibble A table contrasting cond_x and cond_y (interpret as Y/X), with
+#'   one row per `by` group. Columns of interest:
+#'   \describe{
+#'     \item{`delta_log_abund`, `delta_log_abund_se`}{Difference in abundance and
+#'       its standard error, on the log scale given by `log_scale`/`convert_scale`.}
+#'     \item{`delta_p_value`, `delta_q_value`}{Two-sided t test and its
+#'       multiple-testing adjustment.}
+#'     \item{`delta_log_abund_lo`, `delta_log_abund_hi`}{Wald confidence interval
+#'       on `delta_log_abund` at level `1 - alpha`.}
+#'     \item{`df_resid`}{Residual degrees of freedom of the fit, so a caller can
+#'       rebuild the interval or an equivalence test from the table alone.}
+#'     \item{`mdfc80`}{Minimum detectable fold change at the requested `power`:
+#'       the smallest change the contrast could have caught. `NA` where no
+#'       detection limit is defined.}
+#'     \item{`power_at_margin`}{Power to detect a change of `margin`: the dual
+#'       of `mdfc80`, fixing the effect and reporting the power rather than the
+#'       reverse. `NA` on the same rows as `mdfc80`.}
+#'     \item{`margin_fold_change`}{The `margin` used, so the table records what
+#'       it was powered for.}
+#'     \item{`contrast_note`}{Why `mdfc80` and `power_at_margin` are `NA`:
+#'       `"degenerate_fit"` (zero or non-finite SE) or `"insufficient_df"`.
+#'       `NA` when the row is fine.}
+#'     \item{`observed_power`}{Post-hoc power, bit-identical to the column that
+#'       was called `power` before 0.0.3. A deterministic restatement of
+#'       `delta_p_value`, not a measure of precision. Do not filter on it.}
+#'     \item{`power`}{**Deprecated** alias of `observed_power`, retained for one
+#'       release and scheduled for removal.}
+#'   }
+#'
+#'   `mdfc80` and `power_at_margin` are functions of `delta_log_abund_se`,
+#'   `alpha`, `df_resid` and a declared constant only -- never of the observed
+#'   effect. That effect-independence is what makes either of them a fair answer
+#'   to "were we powered to see a phenotype here?", and what makes them safe to
+#'   filter on.
+#'
+#' @details `power` and `mdfc` answered a different question than their names
+#'   suggest, which is what 0.0.3 corrects. `power` substitutes
+#'   the observed Wald statistic for the true effect, making it strictly
+#'   increasing in `|Z|` and so carrying no information beyond `delta_p_value`
+#'   -- `power >= 0.8` is exactly `p <= ~0.008`. It does not measure precision:
+#'   a cell type with a huge standard error and a fluke estimate scores high,
+#'   while a tightly measured genuine null scores the floor. `mdfc` inherits
+#'   that contamination, because a `dplyr::mutate()` binds `power = power` to
+#'   the column created on the line above rather than to the formal argument,
+#'   making the stored value `exp((z_alpha + z_observed) * SE)` -- smallest
+#'   exactly where the data are weakest, and `Inf` on the most significant rows.
+#'
+#'   As of 0.0.3, `power` survives only as a deprecated alias of
+#'   `observed_power`, and the `mdfc` **column is gone**: `calculate_mdfc()` was
+#'   fixed rather than frozen, and now emits `mdfc80`. `mdfc80` is therefore not
+#'   a drop-in for `mdfc` -- it is a different quantity, it differs on
+#'   essentially every row, and any threshold chosen against `mdfc` needs
+#'   rechoosing. To state that a non-significant result excludes a meaningful
+#'   change, compare `mdfc80` to your margin, read `power_at_margin`, or build
+#'   an equivalence test from `delta_log_abund`, `delta_log_abund_se` and
+#'   `df_resid`.
 #' @importFrom dplyr full_join
 #' @export
 compare_abundances <- function(ccm,
@@ -582,6 +730,7 @@ compare_abundances <- function(ccm,
                                method = c("BH", "bonferroni", "hochberg", "hommel", "BY"),
                                alpha = 0.05,
                                power = 0.8,
+                               margin = 2,
                                convert_scale = FALSE,
                                adjust_q_values = FALSE,
                                log_scale = c("log", "log10", "log2")) {
@@ -640,6 +789,28 @@ compare_abundances <- function(ccm,
       )
   }
 
+  # These scalars are bound OUTSIDE the mutate on purpose. dplyr::mutate()
+  # evaluates sequentially against the data mask, so a line reading
+  # `f(power = power)` binds to a `power` COLUMN created earlier in the same
+  # mutate, not to the formal argument. That is precisely how `mdfc` came to be
+  # a function of the observed effect instead of the requested power level.
+  requested_power <- power
+  requested_alpha <- alpha
+
+  # Log scale the contrast columns are on once any conversion above has run,
+  # and the linear base that matches it.
+  result_log_scale <- if (convert_scale) "log2" else log_scale
+  result_base <- log_base_value(result_log_scale)
+
+  df_ok <- length(df.r) == 1 && is.finite(df.r) && df.r > 0
+  tcrit <- if (df_ok) qt(1 - requested_alpha / 2, df.r) else NA_real_
+
+  # `margin` is a FOLD CHANGE, so that it means the same thing whatever log
+  # scale the estimates arrived on. Convert it into that scale here rather than
+  # asking callers to remember whether a 2-fold change is 0.693 or 1.
+  assertthat::assert_that(is.numeric(margin), length(margin) == 1, margin > 0)
+  margin_log <- log(margin, base = result_base)
+
   contrast_tbl <- contrast_tbl %>%
     dplyr::mutate(
       delta_log_abund = log_abund_y - log_abund_x,
@@ -649,26 +820,93 @@ compare_abundances <- function(ccm,
       delta_p_value = ifelse(is.nan(delta_p_value), 1, delta_p_value),
       # delta_p_value = pnorm(abs(delta_log_abund), sd = sqrt(log_abund_se_y^2 + log_abund_se_x^2), lower.tail=FALSE),
       delta_q_value = p.adjust(delta_p_value, method = method),
-      power = calculate_power(log_abund_x, log_abund_se_x, log_abund_y, log_abund_se_y, alpha = alpha),
-      mdfc = calculate_mdfc(log_abund_se_x, log_abund_se_y, power = power)
+
+      # Residual df, published so that a consumer can rebuild a confidence
+      # interval or an equivalence test from the table alone. Previously
+      # computed here and thrown away.
+      df_resid = df.r,
+
+      # Wald CI on the abundance difference, on the same log scale as
+      # delta_log_abund.
+      delta_log_abund_lo = delta_log_abund - tcrit * delta_log_abund_se,
+      delta_log_abund_hi = delta_log_abund + tcrit * delta_log_abund_se,
+
+      # Effect-INDEPENDENT minimum detectable fold change at the requested
+      # `power`. This is the column to filter on, and the one that separates
+      # "no phenotype" from "not powered".
+      mdfc80 = calculate_mdfc(
+        log_abund_se_x, log_abund_se_y,
+        alpha = requested_alpha, power = requested_power,
+        df = df.r, base = result_base
+      ),
+
+      # Why a row has no usable detection limit; NA means the row is fine.
+      contrast_note = dplyr::case_when(
+        rep(!df_ok, dplyr::n()) ~ "insufficient_df",
+        !is.finite(delta_log_abund_se) | delta_log_abund_se <= 0 ~ "degenerate_fit",
+        TRUE ~ NA_character_
+      ),
+
+      # Power to detect a change of `margin`, the dual of mdfc80. Also
+      # effect-independent, so it is a fair answer to "were we powered here?"
+      # and is safe to filter on.
+      power_at_margin = calculate_power_at_margin(
+        log_abund_se_x, log_abund_se_y,
+        alpha = requested_alpha, margin_log = margin_log, df = df.r
+      ),
+
+      # The margin power_at_margin was computed against, so the table says what
+      # it was powered for instead of leaving a reader to guess.
+      margin_fold_change = margin,
+
+      # Post-hoc power. A deterministic restatement of delta_p_value, not a
+      # measure of precision; see the note above calculate_observed_power().
+      # Kept because callers still want the number, under a name that says
+      # what it is. Do not filter on it.
+      observed_power = calculate_observed_power(
+        log_abund_x, log_abund_se_x, log_abund_y, log_abund_se_y,
+        alpha = requested_alpha
+      ),
+
+      # DEPRECATED alias for one release, bit-identical to hooke <= 0.0.2.
+      # Scheduled for removal; use `observed_power`.
+      power = observed_power
     ) %>%
     select(-tvalue)
 
   if (adjust_q_values) {
-    contrast_tbl <- adjust_q_values(contrast_tbl, power_threshold = power)
+    warning(
+      "adjust_q_values = TRUE restricts multiple-testing correction to rows ",
+      "with power_at_margin >= ", requested_power, ". This changes what the ",
+      "FDR guarantee covers: it applies to the adequately powered subset, not ",
+      "to every row tested. Report it as such."
+    )
+    contrast_tbl <- adjust_q_values(contrast_tbl, power_threshold = requested_power)
   }
 
   return(contrast_tbl)
 }
 
-# redo multiple hypothesis correction
-# by only including cell coutns where we have power
-# otherwise return NA
+# Re-runs BH over only the rows whose `power_at_margin` clears a threshold,
+# returning NA elsewhere.
+#
+# This is a defensible filter only because `power_at_margin` is
+# effect-independent: it is a function of the standard errors, `alpha`, `df`
+# and the declared margin, never of the observed effect. The pre-0.0.3 version
+# of this function filtered on the old `power` column, which was a
+# deterministic restatement of `delta_p_value` -- that selected rows by their
+# p-value and then adjusted those same p-values, which is anti-conservative.
+#
+# It still changes the FDR guarantee: the correction now applies to the subset
+# of rows that were adequately powered, not to all rows tested. That is a
+# choice about what the guarantee covers, and callers should say so.
+#
+# Off by default and not enabled in production.
 adjust_q_values <- function(contrast_tbl,
                             power_threshold = 0.8) {
   new_q_values <- contrast_tbl %>%
     mutate(rn = row_number()) %>%
-    filter(power >= power_threshold) %>%
+    filter(power_at_margin >= power_threshold) %>%
     mutate(delta_q_value = p.adjust(delta_p_value, method = "BH")) %>%
     select(rn, delta_q_value)
 

--- a/R/contrasts.R
+++ b/R/contrasts.R
@@ -660,6 +660,14 @@ convert_base <- function(value, from_base, to_base) {
 #'   (so `2` means a two-fold change), used for `power_at_margin`. Given as a
 #'   fold change rather than on a log scale so that it means the same thing
 #'   regardless of `log_scale`/`convert_scale`.
+#'
+#'   The `2` default is a generic convenience, not a policy. A caller using
+#'   `power_at_margin` or `mdfc80` to decide whether a null result is
+#'   *meaningful* should set `margin` to the smallest change they would have
+#'   called a phenotype, so that "we were powered" refers to something that
+#'   would have counted. Setting it larger than that threshold silently
+#'   over-claims: rows whose detection limit is worse than the calling
+#'   threshold still read as adequately powered.
 #' @param convert_scale Whether to convert to log2 scale.
 #' @param adjust_q_values Whether to restrict multiple-testing correction to the
 #'   rows with `power_at_margin >= power`. Changes what the FDR guarantee

--- a/man/compare_abundances.Rd
+++ b/man/compare_abundances.Rd
@@ -12,6 +12,7 @@ compare_abundances(
   method = c("BH", "bonferroni", "hochberg", "hommel", "BY"),
   alpha = 0.05,
   power = 0.8,
+  margin = 2,
   convert_scale = FALSE,
   adjust_q_values = FALSE,
   log_scale = c("log", "log10", "log2")
@@ -30,17 +31,82 @@ compare_abundances(
 This can be "BH" (Benjamini & Hochberg), "bonferroni" (Bonferroni),
 "hochberg" (Hochberg), "hommel", (Hommel), or "BYH" (Benjamini & Yekutieli).}
 
-\item{alpha}{Desired significance level}
+\item{alpha}{Desired significance level.}
 
-\item{power}{Desired power level for calculating minimum detectable fold change}
+\item{power}{Desired power level, used for \code{mdfc80}.}
+
+\item{margin}{The effect size to be powered against, as a \strong{fold change}
+(so \code{2} means a two-fold change), used for \code{power_at_margin}. Given as a
+fold change rather than on a log scale so that it means the same thing
+regardless of \code{log_scale}/\code{convert_scale}.}
 
 \item{convert_scale}{Whether to convert to log2 scale.}
+
+\item{adjust_q_values}{Whether to restrict multiple-testing correction to the
+rows with \code{power_at_margin >= power}. Changes what the FDR guarantee
+covers; see \code{\link[=adjust_q_values]{adjust_q_values()}}. Defaults to \code{FALSE}.}
 
 \item{log_scale}{Log scale used for estimate_abundances.}
 }
 \value{
-tibble A table contrasting cond_x and cond_y (interpret as Y/X).
+tibble A table contrasting cond_x and cond_y (interpret as Y/X), with
+one row per \code{by} group. Columns of interest:
+\describe{
+\item{\code{delta_log_abund}, \code{delta_log_abund_se}}{Difference in abundance and
+its standard error, on the log scale given by \code{log_scale}/\code{convert_scale}.}
+\item{\code{delta_p_value}, \code{delta_q_value}}{Two-sided t test and its
+multiple-testing adjustment.}
+\item{\code{delta_log_abund_lo}, \code{delta_log_abund_hi}}{Wald confidence interval
+on \code{delta_log_abund} at level \code{1 - alpha}.}
+\item{\code{df_resid}}{Residual degrees of freedom of the fit, so a caller can
+rebuild the interval or an equivalence test from the table alone.}
+\item{\code{mdfc80}}{Minimum detectable fold change at the requested \code{power}:
+the smallest change the contrast could have caught. \code{NA} where no
+detection limit is defined.}
+\item{\code{power_at_margin}}{Power to detect a change of \code{margin}: the dual
+of \code{mdfc80}, fixing the effect and reporting the power rather than the
+reverse. \code{NA} on the same rows as \code{mdfc80}.}
+\item{\code{margin_fold_change}}{The \code{margin} used, so the table records what
+it was powered for.}
+\item{\code{contrast_note}}{Why \code{mdfc80} and \code{power_at_margin} are \code{NA}:
+\code{"degenerate_fit"} (zero or non-finite SE) or \code{"insufficient_df"}.
+\code{NA} when the row is fine.}
+\item{\code{observed_power}}{Post-hoc power, bit-identical to the column that
+was called \code{power} before 0.0.3. A deterministic restatement of
+\code{delta_p_value}, not a measure of precision. Do not filter on it.}
+\item{\code{power}}{\strong{Deprecated} alias of \code{observed_power}, retained for one
+release and scheduled for removal.}
+}
+
+\code{mdfc80} and \code{power_at_margin} are functions of \code{delta_log_abund_se},
+\code{alpha}, \code{df_resid} and a declared constant only -- never of the observed
+effect. That effect-independence is what makes either of them a fair answer
+to "were we powered to see a phenotype here?", and what makes them safe to
+filter on.
 }
 \description{
 Compare two estimates of cell abundances from a Hooke model.
+}
+\details{
+\code{power} and \code{mdfc} answered a different question than their names
+suggest, which is what 0.0.3 corrects. \code{power} substitutes
+the observed Wald statistic for the true effect, making it strictly
+increasing in \verb{|Z|} and so carrying no information beyond \code{delta_p_value}
+-- \code{power >= 0.8} is exactly \code{p <= ~0.008}. It does not measure precision:
+a cell type with a huge standard error and a fluke estimate scores high,
+while a tightly measured genuine null scores the floor. \code{mdfc} inherits
+that contamination, because a \code{dplyr::mutate()} binds \code{power = power} to
+the column created on the line above rather than to the formal argument,
+making the stored value \code{exp((z_alpha + z_observed) * SE)} -- smallest
+exactly where the data are weakest, and \code{Inf} on the most significant rows.
+
+As of 0.0.3, \code{power} survives only as a deprecated alias of
+\code{observed_power}, and the \code{mdfc} \strong{column is gone}: \code{calculate_mdfc()} was
+fixed rather than frozen, and now emits \code{mdfc80}. \code{mdfc80} is therefore not
+a drop-in for \code{mdfc} -- it is a different quantity, it differs on
+essentially every row, and any threshold chosen against \code{mdfc} needs
+rechoosing. To state that a non-significant result excludes a meaningful
+change, compare \code{mdfc80} to your margin, read \code{power_at_margin}, or build
+an equivalence test from \code{delta_log_abund}, \code{delta_log_abund_se} and
+\code{df_resid}.
 }

--- a/man/compare_abundances.Rd
+++ b/man/compare_abundances.Rd
@@ -38,7 +38,15 @@ This can be "BH" (Benjamini & Hochberg), "bonferroni" (Bonferroni),
 \item{margin}{The effect size to be powered against, as a \strong{fold change}
 (so \code{2} means a two-fold change), used for \code{power_at_margin}. Given as a
 fold change rather than on a log scale so that it means the same thing
-regardless of \code{log_scale}/\code{convert_scale}.}
+regardless of \code{log_scale}/\code{convert_scale}.
+
+The \code{2} default is a generic convenience, not a policy. A caller using
+\code{power_at_margin} or \code{mdfc80} to decide whether a null result is
+\emph{meaningful} should set \code{margin} to the smallest change they would have
+called a phenotype, so that "we were powered" refers to something that
+would have counted. Setting it larger than that threshold silently
+over-claims: rows whose detection limit is worse than the calling
+threshold still read as adequately powered.}
 
 \item{convert_scale}{Whether to convert to log2 scale.}
 

--- a/tests/testthat/test-contrasts.R
+++ b/tests/testthat/test-contrasts.R
@@ -60,3 +60,222 @@ test_that('compare_abundances problems', {
 
 })
 
+
+
+# ---------------------------------------------------------------------------
+# power / mdfc replacement: mdfc80 and power_at_margin
+# ---------------------------------------------------------------------------
+
+test_that('calculate_mdfc no longer depends on the observed effect', {
+
+  se_x <- c(0.1, 0.4, 1.2)
+  se_y <- c(0.2, 0.4, 0.3)
+
+  mdfc80 <- calculate_mdfc(se_x, se_y, alpha = 0.05, power = 0.8, df = 40)
+
+  # A strictly increasing function of the contrast SE and nothing else. The
+  # column it replaces was essentially uncorrelated with precision.
+  se <- sqrt(se_x^2 + se_y^2)
+  expect_equal(order(mdfc80), order(se))
+  expect_true(all(diff(mdfc80[order(se)]) > 0))
+  expect_equal(cor(mdfc80, se, method = "spearman"), 1)
+
+  # Closed form, with t quantiles to match delta_p_value.
+  expect_equal(mdfc80, exp((qt(0.975, 40) + qt(0.8, 40)) * se))
+
+  # Requesting more power demands a larger detectable effect.
+  expect_true(all(
+    calculate_mdfc(se_x, se_y, power = 0.9, df = 40) > mdfc80
+  ))
+})
+
+
+test_that('calculate_mdfc is base aware', {
+
+  # SEs on a log2 scale must exponentiate in base 2, not base e. The removed
+  # calculate_mdfc() hardcoded exp(), inflating log2 results.
+  se <- sqrt(0.5^2 + 0.5^2)
+  expect_equal(
+    calculate_mdfc(0.5, 0.5, power = 0.8, df = 40, base = 2),
+    2^((qt(0.975, 40) + qt(0.8, 40)) * se)
+  )
+  expect_equal(
+    calculate_mdfc(0.5, 0.5, power = 0.8, df = 40, base = 10),
+    10^((qt(0.975, 40) + qt(0.8, 40)) * se)
+  )
+  expect_gt(
+    calculate_mdfc(0.5, 0.5, power = 0.8, df = 40, base = exp(1)),
+    calculate_mdfc(0.5, 0.5, power = 0.8, df = 40, base = 2)
+  )
+
+  expect_equal(log_base_value("log"), exp(1))
+  expect_equal(log_base_value("log2"), 2)
+  expect_equal(log_base_value("log10"), 10)
+  expect_error(log_base_value("ln"), "Unrecognized log scale")
+})
+
+
+test_that('calculate_power_at_margin does not depend on the observed effect', {
+
+  se_x <- c(0.1, 0.4, 1.2)
+  se_y <- c(0.2, 0.4, 0.3)
+  se <- sqrt(se_x^2 + se_y^2)
+  margin_log <- log(2)
+
+  pwr <- calculate_power_at_margin(se_x, se_y, alpha = 0.05,
+                                   margin_log = margin_log, df = 40)
+
+  # Strictly DEcreasing in SE: the noisier the contrast, the less power.
+  expect_equal(order(pwr), rev(order(se)))
+  expect_equal(cor(pwr, se, method = "spearman"), -1)
+
+  # Closed form: two-sided noncentral t.
+  tcrit <- qt(0.975, 40)
+  expect_equal(
+    pwr,
+    (1 - pt(tcrit, 40, ncp = margin_log / se)) + pt(-tcrit, 40, ncp = margin_log / se)
+  )
+
+  # A bigger change is easier to detect; a stricter alpha is harder.
+  expect_true(all(
+    calculate_power_at_margin(se_x, se_y, margin_log = log(4), df = 40) > pwr
+  ))
+  expect_true(all(
+    calculate_power_at_margin(se_x, se_y, alpha = 0.01,
+                              margin_log = margin_log, df = 40) < pwr
+  ))
+
+  # Sign of the margin is irrelevant -- it is a magnitude.
+  expect_equal(
+    calculate_power_at_margin(se_x, se_y, margin_log = -margin_log, df = 40), pwr
+  )
+
+  # Bounded by alpha from below (a zero margin is just the type I error rate).
+  expect_equal(
+    calculate_power_at_margin(0.3, 0.3, margin_log = 0, df = 40), 0.05
+  )
+})
+
+
+test_that('mdfc80 and power_at_margin are duals of each other', {
+
+  # The two columns answer the same question from opposite ends: fixing the
+  # power and reporting the effect, or fixing the effect and reporting the
+  # power. Powering against a row's own mdfc80 must return the power that
+  # mdfc80 was computed at.
+  se_x <- c(0.1, 0.3, 0.8)
+  se_y <- c(0.2, 0.3, 0.5)
+
+  for (target in c(0.8, 0.9)) {
+    mdfc <- calculate_mdfc(se_x, se_y, power = target, df = 40)
+    back <- calculate_power_at_margin(se_x, se_y, margin_log = log(mdfc), df = 40)
+    # Not exact: mdfc80 uses the (tcrit + t_power) normal-theory form rather
+    # than inverting the noncentral t, which is very slightly conservative.
+    expect_equal(back, rep(target, length(se_x)), tolerance = 0.02)
+    expect_true(all(back >= target))
+  }
+})
+
+
+test_that('the new columns return NA where no answer is defined', {
+
+  # A degenerate fit has no detection limit. It must not report a 1-fold limit,
+  # which is what the removed calculate_mdfc() did once the observed-power
+  # contamination it accidentally depended on was taken away.
+  expect_true(is.na(calculate_mdfc(0, 0, power = 0.8, df = 40)))
+  expect_true(is.na(calculate_power_at_margin(0, 0, margin_log = log(2), df = 40)))
+
+  expect_true(is.na(calculate_mdfc(NA_real_, 0.3, power = 0.8, df = 40)))
+  expect_true(is.na(calculate_power_at_margin(NA_real_, 0.3, margin_log = log(2), df = 40)))
+
+  # Invalid residual df yields no answer either, rather than falling back to a
+  # normal approximation that hides the problem.
+  for (bad_df in list(0, -1, NULL, NA_real_)) {
+    expect_true(is.na(calculate_mdfc(0.3, 0.3, power = 0.8, df = bad_df)))
+    expect_true(is.na(calculate_power_at_margin(0.3, 0.3, margin_log = log(2), df = bad_df)))
+  }
+
+  # Valid rows are untouched by the guard, and keep their position.
+  mdfc80 <- calculate_mdfc(c(0, 0.3), c(0, 0.3), power = 0.8, df = 40)
+  pwr <- calculate_power_at_margin(c(0, 0.3), c(0, 0.3), margin_log = log(2), df = 40)
+  expect_true(is.na(mdfc80[1]) && is.finite(mdfc80[2]))
+  expect_true(is.na(pwr[1]) && is.finite(pwr[2]))
+})
+
+
+test_that('t based detection limits are not the normal approximation', {
+
+  # delta_p_value has always been t based while power/mdfc were z based. With
+  # few samples per arm that mismatch is material, which is why mdfc80 uses t.
+  se <- sqrt(0.3^2 + 0.3^2)
+  z_based <- exp((qnorm(0.975) + qnorm(0.8)) * se)
+
+  expect_gt(calculate_mdfc(0.3, 0.3, power = 0.8, df = 8) / z_based, 1.1)
+  expect_equal(calculate_mdfc(0.3, 0.3, power = 0.8, df = 1e6), z_based,
+               tolerance = 1e-4)
+})
+
+
+test_that('observed_power reproduces the 0.0.2 power column', {
+
+  # `power` survives as a deprecated alias of `observed_power`, so its values
+  # must not move. This pins them against a from-scratch restatement of the
+  # 0.0.2 formula.
+  set.seed(2016)
+  n <- 500
+  se_x <- c(0, abs(rnorm(n - 1, 0.3, 0.1)))
+  se_y <- c(0, abs(rnorm(n - 1, 0.3, 0.1)))
+  beta_x <- rnorm(n)
+  beta_y <- rnorm(n)
+
+  legacy_power <- local({
+    Z <- (beta_x - beta_y) / sqrt(se_x^2 + se_y^2)
+    Z_alpha <- qnorm(1 - 0.05 / 2)
+    p <- 1 - pnorm(Z_alpha - Z) + pnorm(-Z_alpha - Z)
+    ifelse(se_x == 0 & se_y == 0, 0, p)
+  })
+  expect_identical(
+    calculate_observed_power(beta_x, se_x, beta_y, se_y, alpha = 0.05),
+    legacy_power
+  )
+})
+
+
+test_that('mdfc80 is not the old mdfc, and differs in the documented direction', {
+
+  # calculate_mdfc() is fixed rather than frozen, so the published quantity
+  # moves. This records how, so the change stays deliberate.
+  set.seed(2016)
+  n <- 2000
+  se_x <- abs(rnorm(n, 0.3, 0.1))
+  se_y <- abs(rnorm(n, 0.3, 0.1))
+  beta_x <- rnorm(n)
+  beta_y <- rnorm(n)
+  se <- sqrt(se_x^2 + se_y^2)
+
+  obs_power <- calculate_observed_power(beta_x, se_x, beta_y, se_y, alpha = 0.05)
+
+  # The 0.0.2 value: the observed power vector fed in where a requested power
+  # level belonged, and exp() regardless of scale.
+  legacy_mdfc <- exp((qnorm(0.975) + qnorm(obs_power)) * se)
+  mdfc80 <- calculate_mdfc(se_x, se_y, alpha = 0.05, power = 0.8, df = 40)
+
+  # It moves nearly everywhere, and understates on the clear majority of rows.
+  moved <- mean(abs(legacy_mdfc - mdfc80) > 1e-9, na.rm = TRUE)
+  expect_gt(moved, 0.99)
+  finite <- is.finite(legacy_mdfc) & is.finite(mdfc80)
+  expect_gt(mean(legacy_mdfc[finite] < mdfc80[finite]), 0.5)
+
+  # The old value tracked the observed effect; the new one tracks precision.
+  expect_lt(abs(cor(legacy_mdfc[finite], se[finite], method = "spearman")), 0.5)
+  expect_equal(cor(mdfc80, se, method = "spearman"), 1)
+
+  # The old Inf rows were the MOST significant ones (qnorm(1) = Inf), not the
+  # degenerate ones. mdfc80 is finite there and NA only for a degenerate fit.
+  inf_rows <- !is.finite(legacy_mdfc)
+  if (any(inf_rows)) {
+    expect_true(all(obs_power[inf_rows] > 0.99))
+    expect_true(all(is.finite(mdfc80[inf_rows])))
+  }
+  expect_true(is.na(calculate_mdfc(0, 0, alpha = 0.05, power = 0.8, df = 40)))
+})


### PR DESCRIPTION
> **CI note.** `hooke_check_on_push` fails at *Initialize containers* (pulling `monocle3_depend`). This is pre-existing infrastructure, not this change: `develop`'s own last three runs fail at the same step, back to May. No R code is reached.

Step 1 of the `power`/`mdfc` replacement. Upstream of everything else in the series — the columns added here are what the platt, zscapetools and portal PRs consume.

## The problem

`power` substitutes the **observed** Wald statistic for the true effect, making it strictly increasing in `|Z|` and therefore a deterministic restatement of `delta_p_value`: `power >= 0.8` is exactly `p <= ~0.008`. It does not measure precision — a cell type with a huge standard error and a fluke estimate scores high, while a tightly measured genuine null scores the floor. Every "no change, and we were powered" statement built on it was circular.

`mdfc` inherited that contamination: a `dplyr::mutate()` bound `power = power` to the column created on the line above rather than to the formal argument, so the stored value was `exp((z_alpha + z_observed) * SE)` — understated on most rows, smallest exactly where the data are weakest, and `Inf` on the **most** significant rows rather than on degenerate ones.

## Version bump

**`DESCRIPTION` 0.0.2 → 0.0.3**, with the matching `# hooke 0.0.3` section in `NEWS.md` per the repo convention. The design note's "every published number moves, wants a version bump" is satisfied: `mdfc` is removed outright rather than silently changed, and `NEWS.md` leads with a **Breaking changes** section.

## What changed

`calculate_mdfc()` is **fixed rather than frozen** — it now takes `df` and `base`, and its `Inf` guard tests the standard errors alone. (The old guard also tested `power == 0`, so it fired only as a side effect of the contamination; with a constant power it would have reported a 1-fold detection limit for a degenerate fit.) The corrected quantity is published as `mdfc80`; the `mdfc` **column is removed**, since it differs on essentially every row and silently changing it under consumers would be worse than breaking them.

`calculate_power()` → `calculate_observed_power()`, published as `observed_power`, with `power` kept as a **deprecated alias for one release**, bit-identical to 0.0.2.

New columns, all effect-independent — functions of `delta_log_abund_se`, `alpha`, `df_resid` and a declared constant, never of the observed effect:

| column | what it is |
|---|---|
| `mdfc80` | smallest change the contrast could have caught |
| `power_at_margin` | power to detect a change of `margin`, exact noncentral t |
| `margin_fold_change` | the margin used, so the table records what it powered for |
| `delta_log_abund_lo/hi` | Wald CI at `1 - alpha` |
| `df_resid` | residual df, previously computed and discarded |
| `contrast_note` | why `mdfc80` is `NA`: `degenerate_fit` / `insufficient_df` |

New `margin` argument, given as a **fold change** so it means the same thing regardless of `log_scale`/`convert_scale`. Both new statistics use t quantiles, matching `delta_p_value` rather than the normal approximation — on production, recovered residual df runs as low as **7**, where that approximation is badly optimistic.

`adjust_q_values()` now filters on `power_at_margin` rather than `power`, and warns. Filtering on `power` selected rows by their p-value and then adjusted those same p-values, which is anti-conservative. Default unchanged (`FALSE`), not enabled in production.

## Verification

Every retained column verified **bit-identical to 0.0.2** by running the old and new mutate blocks on the same input and comparing column by column. 47 tests, in a file that previously contained only empty stubs.

## Downstream tripwire

`lewis/src/requirements_precompute_helpers.R` lists `power` in `required_dca_cols` and **hard-`stop()`s** if absent. The deprecated alias keeps Lewis running today; whoever removes the alias next release should know Lewis is where it surfaces. That is the right failure mode — loud, not silent — but it should be deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)